### PR TITLE
Limit CMake languages to C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@
 #
 
 # set project name
-project(llnl-hires-timers)
+project(llnl-hires-timers C)
 
 
 # set minimum required CMake version


### PR DESCRIPTION
As this project doesn't use C++, CMake should be able to compile, even with no C++ compiler installed.